### PR TITLE
Fix missing comma in DATABASES dictionary

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -82,7 +82,7 @@ DATABASES = {
     "googledatastore" : "com.yahoo.ycsb.db.GoogleDatastoreClient",
     "graphite"     : "com.yahoo.ycsb.db.GraphiteClient",
     "h5serv"       : "com.yahoo.ycsb.db.H5ServClient",
-    "hana"         : "com.yahoo.ycsb.db.HanaClient"
+    "hana"         : "com.yahoo.ycsb.db.HanaClient",
     "hbase098"     : "com.yahoo.ycsb.db.HBaseClient",
     "hbase10"      : "com.yahoo.ycsb.db.HBaseClient10",
     "hbase12"      : "com.yahoo.ycsb.db.hbase12.HBaseClient12",


### PR DESCRIPTION
Fixes following error when running `bin/yscb` script:
```
File "./bin/ycsb", line 86
    "hbase098"     : "com.yahoo.ycsb.db.HBaseClient",
                   ^
SyntaxError: invalid syntax
```